### PR TITLE
Add freetype-py version pin to address recent CI failures

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   run:
     - python
     - arabic_reshaper >=2.1.0
+    - freetype-py <2.4,>=2.3.0
     - html5lib >=1.0.1
     - pillow >=8.1.1
     - pyhanko >=0.12.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d8e1db3d8acc9ff8071718b89b8967abb561a15d74d2cbd1606539c6d17660c4
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - pisa = xhtml2pdf.pisa:command
     - xhtml2pdf = xhtml2pdf.pisa:command


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Recent CI builds have been failing on a pip version incompatibility related to freetype-py.  This is an attempt to fix by pinning the freetype-py version to 2.3.x.
<!--
Please add any other relevant info below:
-->
